### PR TITLE
Fix issue #300: Buff Prevent and Debuff Prevent bug

### DIFF
--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -85,9 +85,6 @@ export const buffPrevent = (
   if (mainCheck) {
     const info = getInfo(target, effect, "cannot be buffed");
     effect.power = 100;
-    if (effect.isNew && effect.rounds) {
-      effect.rounds -= 1;
-    }
     return info;
   } else if (effect.isNew) {
     effect.rounds = 0;
@@ -108,9 +105,6 @@ export const debuffPrevent = (
   if (mainCheck) {
     const info = getInfo(target, effect, "cannot be debuffed");
     effect.power = 100;
-    if (effect.isNew && effect.rounds) {
-      effect.rounds -= 1;
-    }
     return info;
   } else if (effect.isNew) {
     effect.rounds = 0;


### PR DESCRIPTION
Both the buff prevent and debuff prevent were subtracting 1 turn from the total number of turns that the effect should be active if it was a new effect.  I removed the subtraction so that the number of turns should be correct.

# Pull Request

Removed the subtraction of 1 from the round count.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
